### PR TITLE
Convert PostHog setup script to HTML and uncomment snippet

### DIFF
--- a/wordpress/setup-posthog-on-wordpress.html
+++ b/wordpress/setup-posthog-on-wordpress.html
@@ -1,3 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>PostHog WordPress Setup</title>
+  <script type="text/javascript">
 /**
  * PostHog Initialization Snippet for WordPress (and other basic JS environments)
  *
@@ -26,7 +31,7 @@
 // PASTE YOUR POSTHOG INIT SNIPPET HERE
 // You can find this in your PostHog project settings.
 // It will look something like this:
-/*
+
 !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init be ys Ss me gs ws capture Ne calculateEventProperties xs register register_once register_for_session unregister unregister_for_session Rs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Is ks createPersonProfile Ps bs opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing $s debug Es getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 posthog.init('YOUR_API_KEY', {
   api_host: 'YOUR_API_HOST', // e.g., 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
@@ -35,7 +40,6 @@ posthog.init('YOUR_API_KEY', {
   // autocapture: true,      // Set to true if you want PostHog to attempt to autocapture events (clicks, form submissions)
   // person_profiles: 'always' // Or 'identified_only'
 });
-*/
 
 // =============================================================================
 // END POSTHOG INITIALIZATION
@@ -53,3 +57,14 @@ posthog.init('YOUR_API_KEY', {
 //     { email: userEmail, username: userName } // User properties
 //   );
 // }
+  </script>
+</head>
+<body>
+  <h1>PostHog WordPress Setup</h1>
+  <p>This page includes the PostHog initialization snippet.</p>
+  <p>
+    Remember to replace <code>YOUR_API_KEY</code> and <code>YOUR_API_HOST</code>
+    in the script with your actual PostHog project details.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
I've converted the WordPress PostHog setup JavaScript file to an HTML file. The JavaScript code is now wrapped in <script> tags within a basic HTML structure. The PostHog initialization snippet has been uncommented as per your request. The original .js file has been removed.